### PR TITLE
Bug 1380540: include an extra line to avoid scrollbars

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ can be provided and will be passed through to the component. _Here are a few use
 | `overscanRowCount` | Number |  | Number of rows to render above/below the visible bounds of the list. This can help reduce flickering during scrolling on certain browsers/devices. Defaults to `100`. |
 | `scrollToAlignment` | String |  | Controls the alignment of scrolled-to-rows. The default (`'auto'`) scrolls the least amount possible to ensure that the specified row is fully visible. Use `'start'` to always align rows to the top of the list and `'end'` to align them bottom. Use `'center'` to align them in the middle of container. |
 | `onScroll` | Function |  | Callback invoked whenever the scroll offset changes within the inner scrollable region: `({ clientHeight: number, scrollHeight: number, scrollTop: number }): void` |
+| `extraLines` | Number | | Number of extra lines to show at the bottom of the log; set this to 1 so that Linux users can see the last line of the log output. |
 
 ## `<ScrollFollow />`
 

--- a/src/components/LazyLog/LazyList.js
+++ b/src/components/LazyLog/LazyList.js
@@ -153,6 +153,7 @@ export class LazyList extends React.PureComponent {
 
   renderRow = ({ key, index, style }) => {
     const number = index + 1 + this.state.offset;
+    const line = this.state.lines.get(index);
 
     return (
       <Line
@@ -164,7 +165,7 @@ export class LazyList extends React.PureComponent {
         selectable={this.props.selectableLines}
         highlight={this.state.highlight.includes(number)}
         onLineNumberClick={this.handleHighlight.bind(this, number)}>
-        {ansiparse(decode(this.state.lines.get(index)))}
+        {line && ansiparse(decode(line))}
       </Line>
     );
   };
@@ -187,7 +188,7 @@ export class LazyList extends React.PureComponent {
         {({ height, width }) => (
           <VirtualList
             className={`react-lazylog ${lazyLog}`}
-            rowCount={this.state.count}
+            rowCount={this.state.count + this.props.extraLines}
             rowRenderer={this.renderRow}
             noRowsRenderer={() => this.renderNoRows()}
             {...this.props}
@@ -215,5 +216,6 @@ LazyList.defaultProps = {
     maxWidth: 'initial',
     overflowX: 'scroll'
   },
-  style: {}
+  style: {},
+  extraLines: 0
 };


### PR DESCRIPTION
On Linux, Firefox renders scrollbars all the time, rather than fading
them in and out on hover as occurs on other platforms.  Thus if there is
horizontal scrolling, the last line of a log is always obscured by a
scroll bar.  Typically that last line is the most important one!

This fixes the issue by always including one additional, blank line in
the log output, even while streaming.

Note that this is based on the 2.x series, as tools does not use React 16 yet.