### PR TITLE
Bug 1380540: support extraLines property

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,6 @@ lib
 build
 styleguide
 es5
+
+# Webstorm project specific settings
+.idea/

--- a/src/components/LazyLog/README.md
+++ b/src/components/LazyLog/README.md
@@ -1,7 +1,7 @@
 Normal log viewing:
 
 ```js
-const url = 'https://public-artifacts.taskcluster.net/XEyu7ICDSsGZdSAwPs9Wnw/0/public/logs/live_backing.log';
+const url = 'https://gist.githubusercontent.com/helfi92/96d4444aa0ed46c5f9060a789d316100/raw/ba0d30a9877ea5cc23c7afcd44505dbc2bab1538/typical-live_backing.log';
 
 <div style={{ height: 500, width: 902 }}>
   <LazyLog url={url} />

--- a/src/components/LazyLog/index.jsx
+++ b/src/components/LazyLog/index.jsx
@@ -131,6 +131,12 @@ export default class LazyLog extends Component {
      * Specify an additional className to append to highlighted lines.
      */
     highlightLineClassName: string,
+    /**
+     * Number of extra lines to show at the bottom of the log.
+     * Set this to 1 so that Linux users can see the last line
+     * of the log output.
+     */
+    extraLines: number,
   };
 
   static defaultProps = {
@@ -149,6 +155,7 @@ export default class LazyLog extends Component {
       overflowX: 'scroll',
     },
     style: {},
+    extraLines: 0,
     onError: null,
     onHighlight: null,
     onLoad: null,
@@ -405,6 +412,7 @@ export default class LazyLog extends Component {
     } = this.props;
     const { highlight, lines, offset } = this.state;
     const number = index + 1 + offset;
+    const line = lines.get(index);
 
     return (
       <Line
@@ -418,7 +426,7 @@ export default class LazyLog extends Component {
         selectable={selectableLines}
         highlight={highlight.includes(number)}
         onLineNumberClick={this.handleHighlight}
-        data={ansiparse(decode(lines.get(index)))}
+        data={line && ansiparse(decode(line))}
       />
     );
   };
@@ -456,7 +464,7 @@ export default class LazyLog extends Component {
         {({ height, width }) => (
           <VirtualList
             className={`react-lazylog ${lazyLog}`}
-            rowCount={this.state.count}
+            rowCount={this.state.count + this.props.extraLines}
             rowRenderer={row => this.renderRow(row)}
             noRowsRenderer={this.renderNoRows}
             {...this.props}


### PR DESCRIPTION
This feature was introduced in v2.2.0 but not in v3. From https://github.com/mozilla-frontend-infra/react-lazylog/commit/0d5df76cb50f75ab8c1940cf4b21e61fe932c7f5:

> On Linux, Firefox renders scrollbars all the time, rather than fading
them in and out on hover as occurs on other platforms.  Thus if there is
horizontal scrolling, the last line of a log is always obscured by a
scroll bar.  Typically that last line is the most important one!

> This allows users to work around this issue by including extra, blank
lines at the end of the log output, even while streaming.

Fixes https://github.com/mozilla-frontend-infra/react-lazylog/issues/23.