### PR TITLE
Switch deprecated web-streams-polyfill

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,13 +35,13 @@
     "react-dom": "^16.3.1"
   },
   "dependencies": {
-    "fetch-readablestream": "^0.1.0",
+    "@mattiasbuelens/web-streams-polyfill": "^0.2.0",
+    "fetch-readablestream": "^0.2.0",
     "immutable": "^3.8.2",
     "mitt": "^1.1.2",
     "prop-types": "^15.6.1",
-    "react-virtualized": "^9.10.1",
+    "react-virtualized": "^9.21.0",
     "text-encoding-utf-8": "^1.0.1",
-    "web-streams-polyfill": "^1.3.2",
     "whatwg-fetch": "^2.0.4"
   },
   "peerDependencies": {

--- a/src/stream.js
+++ b/src/stream.js
@@ -6,11 +6,13 @@ const fetcher = Promise.resolve().then(
   () =>
     'ReadableStream' in self && 'body' in self.Response.prototype
       ? self.fetch
-      : import('web-streams-polyfill').then(({ ReadableStream }) => {
-          self.ReadableStream = ReadableStream;
+      : import('@mattiasbuelens/web-streams-polyfill/ponyfill').then(
+          ({ ReadableStream }) => {
+            self.ReadableStream = ReadableStream;
 
-          return import('fetch-readablestream');
-        })
+            return import('fetch-readablestream');
+          }
+        )
 );
 
 export const recurseReaderAsEvent = async (reader, emitter) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -85,6 +85,13 @@
     lodash "^4.2.0"
     to-fast-properties "^2.0.0"
 
+"@mattiasbuelens/web-streams-polyfill@^0.2.0":
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/@mattiasbuelens/web-streams-polyfill/-/web-streams-polyfill-0.2.0.tgz#240cbe5870c6f1b1e72af76675bbbb3191102921"
+  integrity sha512-BH9uGWAm+SpWNVWKCc4NZmQKbJvHpTiz/djkp0/PgWd7FsYKqt2N+7enkYLzV6eRT3wWTfnhrxvbxUn8ogHc2w==
+  dependencies:
+    "@types/whatwg-streams" "^0.0.7"
+
 "@neutrinojs/airbnb-base@^8.1.2":
   version "8.2.1"
   resolved "https://registry.yarnpkg.com/@neutrinojs/airbnb-base/-/airbnb-base-8.2.1.tgz#63cb11321e562b8ef792ef95455a517552c34003"
@@ -357,6 +364,11 @@
     webpack-manifest-plugin "^1.3.2"
     webpack-sources "1.0.1"
     worker-loader "^1.0.0"
+
+"@types/whatwg-streams@^0.0.7":
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/@types/whatwg-streams/-/whatwg-streams-0.0.7.tgz#28bfe73dc850562296367249c4b32a50db81e9d3"
+  integrity sha512-6sDiSEP6DWcY2ZolsJ2s39ZmsoGQ7KVwBDI3sESQsEm9P2dHTcqnDIHRZFRNtLCzWp7hCFGqYbw5GyfpQnJ01A==
 
 abab@^1.0.4:
   version "1.0.4"
@@ -3919,9 +3931,10 @@ fd-slicer@~1.0.1:
   dependencies:
     pend "~1.2.0"
 
-fetch-readablestream@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/fetch-readablestream/-/fetch-readablestream-0.1.0.tgz#2219bccea9bf3b97cb599624094099eafaa400be"
+fetch-readablestream@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/fetch-readablestream/-/fetch-readablestream-0.2.0.tgz#eaa6d1a76b12de2d4731a343393c6ccdcfe2c795"
+  integrity sha512-qu4mXWf4wus4idBIN/kVH+XSer8IZ9CwHP+Pd7DL7TuKNC1hP7ykon4kkBjwJF3EMX2WsFp4hH7gU7CyL7ucXw==
 
 figures@^1.3.5, figures@^1.7.0:
   version "1.7.0"
@@ -7834,6 +7847,11 @@ react-icons@^2.2.7:
   dependencies:
     react-icon-base "2.1.0"
 
+react-lifecycles-compat@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
+  integrity sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==
+
 react-proxy@^3.0.0-alpha.0:
   version "3.0.0-alpha.1"
   resolved "https://registry.yarnpkg.com/react-proxy/-/react-proxy-3.0.0-alpha.1.tgz#4400426bcfa80caa6724c7755695315209fa4b07"
@@ -7902,15 +7920,17 @@ react-styleguidist@^6.2.0:
     webpack-dev-server "^2.9.7"
     webpack-merge "^4.1.2"
 
-react-virtualized@^9.10.1:
-  version "9.18.5"
-  resolved "https://registry.yarnpkg.com/react-virtualized/-/react-virtualized-9.18.5.tgz#42dd390ebaa7ea809bfcaf775d39872641679b89"
+react-virtualized@^9.21.0:
+  version "9.21.0"
+  resolved "https://registry.yarnpkg.com/react-virtualized/-/react-virtualized-9.21.0.tgz#8267c40ffb48db35b242a36dea85edcf280a6506"
+  integrity sha512-duKD2HvO33mqld4EtQKm9H9H0p+xce1c++2D5xn59Ma7P8VT7CprfAe5hwjd1OGkyhqzOZiTMlTal7LxjH5yBQ==
   dependencies:
     babel-runtime "^6.26.0"
     classnames "^2.2.3"
     dom-helpers "^2.4.0 || ^3.0.0"
     loose-envify "^1.3.0"
     prop-types "^15.6.0"
+    react-lifecycles-compat "^3.0.4"
 
 react@^16.3.1:
   version "16.3.1"
@@ -9793,10 +9813,6 @@ wcwidth@^1.0.1:
   resolved "https://registry.yarnpkg.com/wcwidth/-/wcwidth-1.0.1.tgz#f0b0dcf915bc5ff1528afadb2c0e17b532da2fe8"
   dependencies:
     defaults "^1.0.3"
-
-web-streams-polyfill@^1.3.2:
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/web-streams-polyfill/-/web-streams-polyfill-1.3.2.tgz#3719245e909282d93967825f44bcd550e9c03995"
 
 webidl-conversions@^4.0.1, webidl-conversions@^4.0.2:
   version "4.0.2"


### PR DESCRIPTION
When the ReadableStream API is not supported, react-lazylog fallsback to
using web-streams-polyfill[1]. The latter has been deprecated in favor
of @mattiasbuelens/web-streams-polyfill[2].

[1] https://github.com/creatorrr/web-streams-polyfill#readme
[2] https://github.com/MattiasBuelens/web-streams-polyfill

Possibly a fix to https://bugzilla.mozilla.org/show_bug.cgi?id=1506222