### PR TITLE
Bugfix: ScrollFollow component doesn't stop following

### DIFF
--- a/src/components/ScrollFollow/index.jsx
+++ b/src/components/ScrollFollow/index.jsx
@@ -37,23 +37,30 @@ export default class ScrollFollow extends Component {
     startFollowing: bool,
   };
 
-  static defaultProps = {
-    startFollowing: false,
-  };
+  constructor(props) {
+    super(props);
+    // eslint-disable-next-line no-console
+    console.log(props.startFollowing);
 
-  static getDerivedStateFromProps(nextProps) {
-    return {
-      follow: nextProps.startFollowing,
+    this.state = {
+      follow: props.startFollowing,
     };
   }
 
-  state = {
-    follow: false,
-  };
-
   handleScroll = ({ scrollTop, scrollHeight, clientHeight }) => {
-    if (this.state.follow && scrollHeight - scrollTop !== clientHeight) {
+    if (
+      this.state.follow &&
+      scrollHeight - scrollTop !== clientHeight &&
+      clientHeight >= 0
+    ) {
       this.setState({ follow: false });
+    } else if (
+      !this.state.follow &&
+      scrollHeight - scrollTop === clientHeight &&
+      clientHeight >= 0 &&
+      this.props.startFollowing
+    ) {
+      this.setState({ follow: true });
     }
   };
 


### PR DESCRIPTION
Bugfix: ScrollFollow component doesn't stop following when the user scroll up despite setting "startFollowing" prop to true.

Feature: ScrollFollow resumes following when the user scroll all the way
down and the "startFollowing" prop is true.