### PR TITLE
Clean up scrollToIndex prop value passed to react-virualized list

### DIFF
--- a/src/components/LazyLog/index.jsx
+++ b/src/components/LazyLog/index.jsx
@@ -638,9 +638,7 @@ export default class LazyLog extends Component {
               {...this.props}
               height={this.calculateListHeight(height)}
               width={this.props.width === 'auto' ? width : this.props.width}
-              scrollToIndex={
-                this.state.scrollToIndex || this.props.scrollToIndex
-              }
+              scrollToIndex={this.state.scrollToIndex}
             />
           )}
         </AutoSizer>


### PR DESCRIPTION
The `Lazylog` component does not have a `scrollToIndex` prop. The code never hit `this.props.scrollToIndex` because `this.state.scrollToIndex` was always truthy.

/cc @helfi92 