### PR TITLE
Add a `pollInterval` option to poll for updates from the logs

### DIFF
--- a/src/components/LazyLog/index.jsx
+++ b/src/components/LazyLog/index.jsx
@@ -267,13 +267,7 @@ export default class LazyLog extends Component {
 
   componentWillUnmount() {
     this.endRequest();
-
-    if (props.pollInterval !== null) {
-      this.interval = setInterval(
-        this.request.bind(this),
-        this.props.pollInterval
-      )
-    }
+    this.pollInterval && clearInterval(this.pollInterval);
   }
 
   request() {
@@ -300,7 +294,12 @@ export default class LazyLog extends Component {
   }
 
   schedulePoll() {
-    this.interval && clearInterval(this.interval)
+    if (this.props.pollInterval !== null) {
+      this.interval = setInterval(
+        this.request.bind(this),
+        this.props.pollInterval
+      );
+    }
   }
 
   handleUpdate = ({ lines: moreLines, encodedLog }) => {

--- a/src/components/LazyLog/index.jsx
+++ b/src/components/LazyLog/index.jsx
@@ -267,7 +267,7 @@ export default class LazyLog extends Component {
 
   componentWillUnmount() {
     this.endRequest();
-    this.pollInterval && clearInterval(this.pollInterval);
+    this.interval && clearInterval(this.interval);
   }
 
   request() {

--- a/src/components/LazyLog/index.jsx
+++ b/src/components/LazyLog/index.jsx
@@ -267,7 +267,7 @@ export default class LazyLog extends Component {
 
   componentWillUnmount() {
     this.endRequest();
-    this.interval && clearInterval(this.interval);
+    this.cancelPoll();
   }
 
   request() {
@@ -299,7 +299,14 @@ export default class LazyLog extends Component {
         this.request.bind(this),
         this.props.pollInterval
       );
+    } else {
+      this.cancelPoll();
     }
+  }
+
+  cancelPoll() {
+    this.interval && clearInterval(this.interval);
+    this.interval = null;
   }
 
   handleUpdate = ({ lines: moreLines, encodedLog }) => {


### PR DESCRIPTION
I would like to occasionally poll for updates to the logs. Right now the only way to do this is a hack to add an ignored query parameter to the url every n milliseconds, forcing the url to reload

(I know that polling for logs isn't the ideal implementation for things, but I don't control the server I'm connecting to in this situation, and a poll would be very useful)