### PR TITLE
Add option to capture system hotkeys for search

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   "dependencies": {
     "@mattiasbuelens/web-streams-polyfill": "^0.2.0",
     "fetch-readablestream": "^0.2.0",
+    "hotkeys-js": "^3.7.3",
     "immutable": "^3.8.2",
     "mitt": "^1.1.2",
     "prop-types": "^15.6.1",

--- a/src/components/LazyLog/index.jsx
+++ b/src/components/LazyLog/index.jsx
@@ -182,6 +182,11 @@ export default class LazyLog extends Component {
      * Flag to enable/disable case insensitive search
      */
     caseInsensitive: bool,
+    /**
+     * If true, capture system hotkeys for searching the page (Cmd-F, Ctrl-F,
+     * etc.)
+     */
+    captureHotkeys: bool,
   };
 
   static defaultProps = {
@@ -213,6 +218,7 @@ export default class LazyLog extends Component {
     lineClassName: '',
     highlightLineClassName: '',
     caseInsensitive: false,
+    captureHotkeys: false,
   };
 
   static getDerivedStateFromProps(
@@ -701,6 +707,7 @@ export default class LazyLog extends Component {
             onFilterLinesWithMatches={this.handleFilterLinesWithMatches}
             resultsCount={resultLines.length}
             disabled={count === 0}
+            captureHotkeys={this.props.captureHotkeys}
           />
         )}
         <AutoSizer

--- a/src/components/SearchBar/index.jsx
+++ b/src/components/SearchBar/index.jsx
@@ -1,5 +1,6 @@
-import { Component } from 'react';
+import { createRef, Component } from 'react';
 import { bool, func, number } from 'prop-types';
+import hotkeys from 'hotkeys-js';
 import FilterLinesIcon from './FilterLinesIcon';
 import { SEARCH_MIN_KEYWORDS } from '../../utils';
 import {
@@ -38,6 +39,11 @@ export default class SearchBar extends Component {
      * If true, the input field and filter button will be disabled.
      */
     disabled: bool,
+    /**
+     * If true, capture system hotkeys for searching the page (Cmd-F, Ctrl-F,
+     * etc.)
+     */
+    captureHotkeys: bool,
   };
 
   static defaultProps = {
@@ -47,11 +53,17 @@ export default class SearchBar extends Component {
     resultsCount: 0,
     filterActive: false,
     disabled: false,
+    captureHotkeys: false,
   };
 
   state = {
     keywords: '',
   };
+
+  constructor(props) {
+    super(props);
+    this.inputRef = createRef();
+  }
 
   handleFilterToggle = () => {
     this.props.onFilterLinesWithMatches(!this.props.filterActive);
@@ -80,6 +92,21 @@ export default class SearchBar extends Component {
     }
   };
 
+  handleSearchHotkey = e => {
+    if (!this.inputRef.current) {
+      return;
+    }
+
+    e.preventDefault();
+    this.inputRef.current.focus();
+  };
+
+  componentDidMount() {
+    if (this.props.captureHotkeys) {
+      hotkeys('ctrl+f,cmd+f', this.handleSearchHotkey);
+    }
+  }
+
   render() {
     const { resultsCount, filterActive, disabled } = this.props;
     const matchesLabel = `match${resultsCount === 1 ? '' : 'es'}`;
@@ -97,6 +124,7 @@ export default class SearchBar extends Component {
           onKeyPress={this.handleSearchKeyPress}
           value={this.state.keywords}
           disabled={disabled}
+          ref={this.inputRef}
         />
         <button
           disabled={disabled}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5300,6 +5300,11 @@ hosted-git-info@^2.1.4:
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.8.4.tgz#44119abaf4bc64692a16ace34700fed9c03e2546"
   integrity sha512-pzXIvANXEFrc5oFFXRMkbLPQ2rXRoDERwDLyrcUxGhaZhgP54BBSl9Oheh7Vv0T090cszWBxPjkQQ5Sq1PbBRQ==
 
+hotkeys-js@^3.7.3:
+  version "3.7.3"
+  resolved "https://registry.yarnpkg.com/hotkeys-js/-/hotkeys-js-3.7.3.tgz#f0c718166e844b3e52065d1b60cffaa6065b5183"
+  integrity sha512-CSaeVPAKEEYNexYR35znMJnCqoofk7oqG/AOOqWow1qDT0Yxy+g+Y8Hs/LhGlsZaSJ7973YN6/N41LAr3t30QQ==
+
 hpack.js@^2.1.6:
   version "2.1.6"
   resolved "https://registry.yarnpkg.com/hpack.js/-/hpack.js-2.1.6.tgz#87774c0949e513f42e84575b3c45681fade2a0b2"


### PR DESCRIPTION
This adds an option to capture the system search shortcuts (Cmd-F, Ctrl-F), triggering a focus of the search box when pressed. This is intended to make search behavior less confusing, since the log rendering is virtualized and the browser can't search lines that aren't rendered.

This is a proof-of-concept that needs a little bit of additional work (to unregister the handler on unmount, for instance), but I wanted to solicit initial feedback before going too far.