### PR TITLE
Ensure WebSocket format message returns a string

### DIFF
--- a/src/websocket.js
+++ b/src/websocket.js
@@ -46,7 +46,7 @@ export default (url, options) => {
 
       socket.addEventListener('message', e => {
         let msg = formatMessage ? formatMessage(e.data) : e.data;
-
+        if (typeof(msg) !== 'string') return;
         // add a new line character between each message if one doesn't exist.
         // this allows our search index to properly distinguish new lines.
         msg = msg.endsWith('\n') ? msg : `${msg}\n`;


### PR DESCRIPTION
For the WebSocket event listener, a console error is thrown from `msg = msg.endsWith('\n') ? msg : ${msg}\n;` if a formatMessage function does not return a string.

Rather than throwing an error, return from the function if a string is not provided.