### PR TITLE
Allow adding offset to line numbers

### DIFF
--- a/src/components/LazyLog/README.md
+++ b/src/components/LazyLog/README.md
@@ -63,3 +63,29 @@ let socket = null;
   </div>
 </div>
 ```
+
+Adding a 10000 line offset to the line number (useful when displaying the tail of a large log file):
+
+```jsx harmony
+const text = `Sed ut perspiciatis unde omnis iste natus error sit voluptatem
+accusantium doloremque laudantium, totam rem aperiam,
+eaque ipsa quae ab illo inventore veritatis et quasi architecto
+beatae vitae dicta sunt explicabo. Nemo enim ipsam
+voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed
+quia consequuntur magni dolores eos qui ratione
+voluptatem sequi nesciunt. Neque porro quisquam est, qui dolorem
+ipsum quia dolor sit amet, consectetur, adipisci
+velit, sed quia non numquam eius modi tempora incidunt ut labore
+et dolore magnam aliquam quaerat voluptatem.
+
+Ut enim ad minima veniam, quis nostrum exercitationem ullam corporis suscipit
+laboriosam, nisi ut aliquid ex ea commodi consequatur? Quis autem vel eum iure
+reprehenderit qui in ea voluptate velit esse quam nihil molestiae
+consequatur, vel illum qui dolorem eum fugiat quo voluptas nulla pariatur?
+`;
+
+<div style={{ height: 300, width: 902 }}>
+  <LazyLog extraLines={1} enableSearch startingLineNumberOffset={10000} text={text} caseInsensitive />
+</div>
+```
+

--- a/src/components/LazyLog/index.jsx
+++ b/src/components/LazyLog/index.jsx
@@ -21,6 +21,7 @@ import {
   getHighlightRange,
   searchFormatPart,
   convertBufferToLines,
+  isNumber,
 } from '../../utils';
 import Line from '../Line';
 import Loading from '../Loading';
@@ -182,6 +183,10 @@ export default class LazyLog extends Component {
      * Flag to enable/disable case insensitive search
      */
     caseInsensitive: bool,
+    /**
+     * Offset of starting line number
+     */
+    startingLineNumberOffset: number,
   };
 
   static defaultProps = {
@@ -213,6 +218,7 @@ export default class LazyLog extends Component {
     lineClassName: '',
     highlightLineClassName: '',
     caseInsensitive: false,
+    startingLineNumberOffset: 0,
   };
 
   static getDerivedStateFromProps(
@@ -624,6 +630,7 @@ export default class LazyLog extends Component {
       selectableLines,
       lineClassName,
       highlightLineClassName,
+      startingLineNumberOffset,
     } = this.props;
     const {
       highlight,
@@ -634,9 +641,10 @@ export default class LazyLog extends Component {
       resultLineUniqueIndexes,
     } = this.state;
     const linesToRender = isFilteringLinesWithMatches ? filteredLines : lines;
-    const number = isFilteringLinesWithMatches
-      ? resultLineUniqueIndexes[index]
-      : index + 1 + offset;
+    const numberComputed = isFilteringLinesWithMatches
+      ? resultLineUniqueIndexes[index] + startingLineNumberOffset
+      : index + 1 + offset + startingLineNumberOffset;
+    const number = isNumber(numberComputed) ? numberComputed : undefined;
 
     return (
       <Line

--- a/src/utils.js
+++ b/src/utils.js
@@ -131,3 +131,5 @@ export const searchFormatPart = ({
 
   return formattedPart;
 };
+
+export const isNumber = x => !Number.isNaN(Number(x));


### PR DESCRIPTION
## PR background

We came up with a use case when loading a large log file into our web browser, but that file was too large to fetch (around 1M lines+) so both bandwidth and memory of the server will suffer.

Our current solution is to limit the payload to approximately 5000 lines on the tail of that log file, for usually the most useful information would be on that section.

Adding an offset to the line number will be useful to tell our user the actual total line number in that log file.
